### PR TITLE
feat(auth): add bearer token support for private models

### DIFF
--- a/src/main/java/io/gravitee/reactive/webclient/api/FetchModelConfig.java
+++ b/src/main/java/io/gravitee/reactive/webclient/api/FetchModelConfig.java
@@ -18,4 +18,8 @@ package io.gravitee.reactive.webclient.api;
 import java.nio.file.Path;
 import java.util.List;
 
-public record FetchModelConfig(String modelName, List<ModelFile> modelFiles, Path modelDirectory) {}
+public record FetchModelConfig(String modelName, List<ModelFile> modelFiles, Path modelDirectory, String token) {
+    public FetchModelConfig(String modelName, List<ModelFile> modelFiles, Path modelDirectory) {
+        this(modelName, modelFiles, modelDirectory, null);
+    }
+}

--- a/src/main/java/io/gravitee/reactive/webclient/api/FetchModelConfig.java
+++ b/src/main/java/io/gravitee/reactive/webclient/api/FetchModelConfig.java
@@ -22,4 +22,23 @@ public record FetchModelConfig(String modelName, List<ModelFile> modelFiles, Pat
     public FetchModelConfig(String modelName, List<ModelFile> modelFiles, Path modelDirectory) {
         this(modelName, modelFiles, modelDirectory, null);
     }
+
+    @Override
+    public String toString() {
+        return (
+            "FetchModelConfig[" +
+            "modelName=" +
+            modelName +
+            ", " +
+            "modelFiles=" +
+            modelFiles +
+            ", " +
+            "modelDirectory=" +
+            modelDirectory +
+            ", " +
+            "token=" +
+            (token == null ? "null" : "********") +
+            "]"
+        );
+    }
 }

--- a/src/main/java/io/gravitee/reactive/webclient/huggingface/client/HuggingFaceClientRx.java
+++ b/src/main/java/io/gravitee/reactive/webclient/huggingface/client/HuggingFaceClientRx.java
@@ -21,7 +21,15 @@ import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.core.streams.WriteStream;
 
 public interface HuggingFaceClientRx {
-    Flowable<String> listModelFiles(String modelName);
+    default Flowable<String> listModelFiles(String modelName) {
+        return listModelFiles(modelName, null);
+    }
 
-    Completable downloadModelFile(String modelName, String fileName, WriteStream<Buffer> file);
+    Flowable<String> listModelFiles(String modelName, String token);
+
+    default Completable downloadModelFile(String modelName, String fileName, WriteStream<Buffer> file) {
+        return downloadModelFile(modelName, fileName, file, null);
+    }
+
+    Completable downloadModelFile(String modelName, String fileName, WriteStream<Buffer> file, String token);
 }

--- a/src/main/java/io/gravitee/reactive/webclient/huggingface/client/VertxHuggingFaceClientRx.java
+++ b/src/main/java/io/gravitee/reactive/webclient/huggingface/client/VertxHuggingFaceClientRx.java
@@ -22,6 +22,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.core.streams.WriteStream;
+import io.vertx.rxjava3.ext.web.client.HttpRequest;
 import io.vertx.rxjava3.ext.web.client.WebClient;
 import io.vertx.rxjava3.ext.web.codec.BodyCodec;
 import java.util.List;
@@ -43,10 +44,11 @@ public class VertxHuggingFaceClientRx implements HuggingFaceClientRx {
     }
 
     @Override
-    public Flowable<String> listModelFiles(String modelName) {
+    public Flowable<String> listModelFiles(String modelName, String token) {
         var request = client.request(HttpMethod.GET, "/api/models/" + modelName);
+        request.putHeader("Accept", "application/json");
+        withBearerToken(request, token);
         return request
-            .putHeader("Accept", "application/json")
             .rxSend()
             .map(response -> response.body().toJsonObject().getJsonArray(SIBLINGS_KEY))
             .flattenAsFlowable(VertxHuggingFaceClientRx::getFileNames)
@@ -56,12 +58,12 @@ public class VertxHuggingFaceClientRx implements HuggingFaceClientRx {
     }
 
     @Override
-    public Completable downloadModelFile(String modelName, String fileName, WriteStream<Buffer> file) {
+    public Completable downloadModelFile(String modelName, String fileName, WriteStream<Buffer> file, String token) {
         log.debug("Downloading file [{}] from model [{}]", fileName, modelName);
         var request = client.request(HttpMethod.GET, String.format(HF_REPO_BASE_URL, modelName, fileName));
+        request.addQueryParam("download", "true").followRedirects(true);
+        withBearerToken(request, token);
         return request
-            .addQueryParam("download", "true")
-            .followRedirects(true)
             .as(BodyCodec.pipe(file))
             .rxSend()
             .flatMapCompletable(response -> {
@@ -82,6 +84,12 @@ public class VertxHuggingFaceClientRx implements HuggingFaceClientRx {
             })
             .doOnComplete(() -> log.info("Downloaded model file [{}] successfully", fileName))
             .doOnError(err -> log.error("Failed to download [{}]: {}", fileName, err.getMessage(), err));
+    }
+
+    private static <T> void withBearerToken(HttpRequest<T> request, String token) {
+        if (token != null && !token.isBlank()) {
+            request.putHeader("Authorization", "Bearer " + token);
+        }
     }
 
     private static List<String> getFileNames(JsonArray siblings) {

--- a/src/main/java/io/gravitee/reactive/webclient/huggingface/downloader/HuggingFaceDownloader.java
+++ b/src/main/java/io/gravitee/reactive/webclient/huggingface/downloader/HuggingFaceDownloader.java
@@ -51,7 +51,7 @@ public class HuggingFaceDownloader implements ModelFetcher {
     @Override
     public Single<Map<ModelFileType, String>> fetchModel(FetchModelConfig config) {
         return modelDownloader
-            .listModelFiles(config.modelName())
+            .listModelFiles(config.modelName(), config.token())
             .toList()
             .flatMapPublisher(availableFiles ->
                 Flowable
@@ -86,7 +86,7 @@ public class HuggingFaceDownloader implements ModelFetcher {
                                     isFileInSubDirectory ? buildSubDirectoryAndOpenFile(outputPath) : openFile(outputPath)
                                 ).flatMap(file ->
                                         modelDownloader
-                                            .downloadModelFile(config.modelName(), modelFile.name(), file)
+                                            .downloadModelFile(config.modelName(), modelFile.name(), file, config.token())
                                             .doFinally(file::close)
                                             .andThen(Single.just(Map.entry(modelFile.type(), outputPath.toString())))
                                             .onErrorResumeNext(err ->

--- a/src/test/java/client/VertxHuggingFaceClientRxTest.java
+++ b/src/test/java/client/VertxHuggingFaceClientRxTest.java
@@ -18,10 +18,12 @@ package client;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
@@ -166,6 +168,100 @@ class VertxHuggingFaceClientRxTest {
         } finally {
             Files.deleteIfExists(tempFile);
         }
+    }
+
+    @Test
+    void shouldListModelFilesWithAuthorizationHeaderWhenTokenProvided() {
+        // given
+        String token = "hf_test_token_123";
+        stubFor(
+            get(urlEqualTo("/api/models/private-org/private-model"))
+                .willReturn(
+                    okJson(
+                        """
+            {
+              "siblings": [
+                { "rfilename": "config.json" }
+              ]
+            }
+        """
+                    )
+                )
+        );
+
+        // when
+        List<String> files = huggingFaceClient.listModelFiles("private-org/private-model", token).toList().blockingGet();
+
+        // then
+        assertThat(files).containsExactly("config.json");
+        verify(
+            getRequestedFor(urlEqualTo("/api/models/private-org/private-model")).withHeader("Authorization", equalTo("Bearer " + token))
+        );
+    }
+
+    @Test
+    void shouldDownloadModelFileWithAuthorizationHeaderWhenTokenProvided() throws IOException {
+        // given
+        String modelName = "private-org/private-model";
+        String fileName = "config.json";
+        String fileContent = """
+            {"key": "value"}
+            """;
+        String token = "hf_test_token_123";
+
+        stubFor(
+            get(urlPathEqualTo("/private-org/private-model/resolve/main/config.json"))
+                .withQueryParam("download", equalTo("true"))
+                .willReturn(aResponse().withStatus(200).withBody(fileContent))
+        );
+
+        Vertx vertx = Vertx.vertx();
+        Path tempFile = Files.createTempFile("hf-test-", ".json");
+        AsyncFile asyncFile = vertx
+            .fileSystem()
+            .rxOpen(tempFile.toString(), new OpenOptions().setCreate(true).setWrite(true).setTruncateExisting(true))
+            .blockingGet();
+
+        try {
+            // when
+            huggingFaceClient.downloadModelFile(modelName, fileName, asyncFile, token).blockingAwait();
+
+            // then
+            String result = Files.readString(tempFile);
+            assertThat(result).isEqualTo(fileContent);
+            verify(
+                getRequestedFor(urlPathEqualTo("/private-org/private-model/resolve/main/config.json"))
+                    .withHeader("Authorization", equalTo("Bearer " + token))
+            );
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    void shouldNotSendAuthorizationHeaderWhenTokenIsNull() {
+        // given
+        stubFor(
+            get(urlEqualTo("/api/models/public-org/public-model"))
+                .willReturn(
+                    okJson(
+                        """
+            {
+              "siblings": [
+                { "rfilename": "model.bin" }
+              ]
+            }
+        """
+                    )
+                )
+        );
+
+        // when
+        List<String> files = huggingFaceClient.listModelFiles("public-org/public-model", null).toList().blockingGet();
+
+        // then
+        assertThat(files).containsExactly("model.bin");
+        verify(getRequestedFor(urlEqualTo("/api/models/public-org/public-model")).withoutHeader("Authorization"));
     }
 
     @Test

--- a/src/test/java/downloader/HuggingFaceDownloaderTest.java
+++ b/src/test/java/downloader/HuggingFaceDownloaderTest.java
@@ -58,7 +58,7 @@ class HuggingFaceDownloaderTest {
         when(fileSystem.rxExists(modelDir.resolve(file.name()).toString())).thenReturn(Single.just(true));
 
         var client = mock(VertxHuggingFaceClientRx.class);
-        when(client.listModelFiles(modelName)).thenReturn(Flowable.just("config.json"));
+        when(client.listModelFiles(modelName, null)).thenReturn(Flowable.just("config.json"));
 
         var service = new HuggingFaceDownloader(vertx, client);
 
@@ -93,8 +93,8 @@ class HuggingFaceDownloaderTest {
         when(fileSystem.rxOpen(eq(modelDir.resolve(file.name()).toString()), any())).thenReturn(Single.just(asyncFile));
 
         var client = mock(VertxHuggingFaceClientRx.class);
-        when(client.listModelFiles(modelName)).thenReturn(Flowable.just(file.name()));
-        when(client.downloadModelFile(modelName, file.name(), asyncFile)).thenReturn(Completable.complete());
+        when(client.listModelFiles(modelName, null)).thenReturn(Flowable.just(file.name()));
+        when(client.downloadModelFile(modelName, file.name(), asyncFile, null)).thenReturn(Completable.complete());
 
         var fetcher = new HuggingFaceDownloader(vertx, client);
 
@@ -108,7 +108,7 @@ class HuggingFaceDownloaderTest {
                 assertThat(result.get(ModelFileType.CONFIG)).contains("temp-model-dir/config.json");
                 return true;
             });
-        verify(client).downloadModelFile(modelName, file.name(), asyncFile);
+        verify(client).downloadModelFile(modelName, file.name(), asyncFile, null);
         verify(asyncFile).close();
     }
 
@@ -129,8 +129,8 @@ class HuggingFaceDownloaderTest {
         when(fileSystem.rxOpen(eq(modelDir.resolve(file.name()).toString()), any())).thenReturn(Single.just(asyncFile));
 
         var client = mock(VertxHuggingFaceClientRx.class);
-        when(client.listModelFiles(modelName)).thenReturn(Flowable.just(file.name()));
-        when(client.downloadModelFile(modelName, file.name(), asyncFile)).thenReturn(Completable.complete());
+        when(client.listModelFiles(modelName, null)).thenReturn(Flowable.just(file.name()));
+        when(client.downloadModelFile(modelName, file.name(), asyncFile, null)).thenReturn(Completable.complete());
 
         var fetcher = new HuggingFaceDownloader(vertx, client);
 
@@ -144,7 +144,7 @@ class HuggingFaceDownloaderTest {
                 assertThat(result.get(ModelFileType.CONFIG)).contains("temp-model-dir/config/config.json");
                 return true;
             });
-        verify(client).downloadModelFile(modelName, file.name(), asyncFile);
+        verify(client).downloadModelFile(modelName, file.name(), asyncFile, null);
         verify(asyncFile).close();
     }
 
@@ -156,7 +156,7 @@ class HuggingFaceDownloaderTest {
         Path modelDir = Path.of("temp-model-dir");
 
         var client = mock(VertxHuggingFaceClientRx.class);
-        when(client.listModelFiles(modelName)).thenReturn(Flowable.just("other_file.json"));
+        when(client.listModelFiles(modelName, null)).thenReturn(Flowable.just("other_file.json"));
 
         var fetcher = new HuggingFaceDownloader(mock(Vertx.class), client);
 
@@ -181,8 +181,8 @@ class HuggingFaceDownloaderTest {
         when(asyncFile.close()).thenReturn(Completable.complete());
 
         var client = mock(VertxHuggingFaceClientRx.class);
-        when(client.listModelFiles(modelName)).thenReturn(Flowable.just("model.onnx"));
-        when(client.downloadModelFile(modelName, "model.onnx", asyncFile))
+        when(client.listModelFiles(modelName, null)).thenReturn(Flowable.just("model.onnx"));
+        when(client.downloadModelFile(modelName, "model.onnx", asyncFile, null))
             .thenReturn(Completable.error(new RuntimeException("network timeout")));
 
         var fetcher = new HuggingFaceDownloader(vertx, client);


### PR DESCRIPTION
## Summary

- Add bearer token authentication support to access private HuggingFace models
- Update `FetchModelConfig` to include an optional auth token field
- Update `HuggingFaceClientRx` and `VertxHuggingFaceClientRx` to pass the bearer token in HTTP requests
- Update `HuggingFaceDownloader` to propagate the auth token
- Add/update tests covering authenticated and unauthenticated scenarios

## Test plan

- [x] `VertxHuggingFaceClientRxTest` — verify bearer token is sent in requests to private repos
- [x] `HuggingFaceDownloaderTest` — verify token propagation through the downloader
- [x] Manual test: fetch a private model using a valid HuggingFace token
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-feat-private-repos-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reactive/webclient/gravitee-reactive-webclient-huggingface/1.2.0-feat-private-repos-SNAPSHOT/gravitee-reactive-webclient-huggingface-1.2.0-feat-private-repos-SNAPSHOT.zip)
  <!-- Version placeholder end -->
