### PR TITLE
fix(downloader): skip HF listing when all files exist locally

### DIFF
--- a/src/main/java/io/gravitee/reactive/webclient/huggingface/downloader/HuggingFaceDownloader.java
+++ b/src/main/java/io/gravitee/reactive/webclient/huggingface/downloader/HuggingFaceDownloader.java
@@ -17,6 +17,7 @@ package io.gravitee.reactive.webclient.huggingface.downloader;
 
 import io.gravitee.reactive.webclient.api.FetchModelConfig;
 import io.gravitee.reactive.webclient.api.ModelFetcher;
+import io.gravitee.reactive.webclient.api.ModelFile;
 import io.gravitee.reactive.webclient.api.ModelFileType;
 import io.gravitee.reactive.webclient.huggingface.client.VertxHuggingFaceClientRx;
 import io.gravitee.reactive.webclient.huggingface.exception.ModelDownloadFailedException;
@@ -28,6 +29,7 @@ import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.file.AsyncFile;
 import java.nio.file.Path;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,61 +52,75 @@ public class HuggingFaceDownloader implements ModelFetcher {
 
     @Override
     public Single<Map<ModelFileType, String>> fetchModel(FetchModelConfig config) {
+        return Flowable
+            .fromIterable(config.modelFiles())
+            .flatMapSingle(modelFile -> {
+                var outputPath = config.modelDirectory().resolve(modelFile.name());
+                return vertx.fileSystem().rxExists(outputPath.toString()).map(exists -> new FileStatus(modelFile, outputPath, exists));
+            })
+            .toList()
+            .flatMap(statuses -> {
+                if (statuses.stream().allMatch(FileStatus::exists)) {
+                    log.info("All model files already exist locally, skipping HuggingFace listing");
+                    var result = new EnumMap<ModelFileType, String>(ModelFileType.class);
+                    statuses.forEach(s -> result.put(s.modelFile().type(), s.outputPath().toString()));
+                    return Single.just(result);
+                }
+                return downloadWithHuggingFaceVerification(config, statuses);
+            });
+    }
+
+    private Single<Map<ModelFileType, String>> downloadWithHuggingFaceVerification(FetchModelConfig config, List<FileStatus> statuses) {
         return modelDownloader
             .listModelFiles(config.modelName())
             .toList()
             .flatMapPublisher(availableFiles ->
                 Flowable
-                    .fromIterable(config.modelFiles())
-                    .flatMapSingle(modelFile -> {
-                        if (!availableFiles.contains(modelFile.name())) {
+                    .fromIterable(statuses)
+                    .flatMapSingle(status -> {
+                        if (status.exists()) {
+                            log.info("Skipping download; file already exists: {}", status.modelFile().name());
+                            return Single.just(Map.entry(status.modelFile().type(), status.outputPath().toString()));
+                        }
+
+                        if (!availableFiles.contains(status.modelFile().name())) {
                             return Single.error(
                                 new ModelFileNotFoundException(
                                     String.format(
                                         "Model file not found on HuggingFace: %s for model: %s",
-                                        modelFile.name(),
+                                        status.modelFile().name(),
                                         config.modelName()
                                     )
                                 )
                             );
                         }
 
-                        Path outputPath = config.modelDirectory().resolve(modelFile.name());
+                        boolean isFileInSubDirectory = status.outputPath().toString().contains("/");
 
-                        return vertx
-                            .fileSystem()
-                            .rxExists(outputPath.toString())
-                            .flatMap(exists -> {
-                                if (exists) {
-                                    log.info("Skipping download; file already exists: {}", modelFile.name());
-                                    return Single.just(Map.entry(modelFile.type(), outputPath.toString()));
-                                }
-
-                                boolean isFileInSubDirectory = outputPath.toString().contains("/");
-
-                                return (
-                                    isFileInSubDirectory ? buildSubDirectoryAndOpenFile(outputPath) : openFile(outputPath)
-                                ).flatMap(file ->
-                                        modelDownloader
-                                            .downloadModelFile(config.modelName(), modelFile.name(), file)
-                                            .doFinally(file::close)
-                                            .andThen(Single.just(Map.entry(modelFile.type(), outputPath.toString())))
-                                            .onErrorResumeNext(err ->
-                                                Single.error(
-                                                    new ModelDownloadFailedException(
-                                                        String.format("Download failed for model: %s", modelFile.name()),
-                                                        err
-                                                    )
-                                                )
+                        return (
+                            isFileInSubDirectory ? buildSubDirectoryAndOpenFile(status.outputPath()) : openFile(status.outputPath())
+                        ).flatMap(file ->
+                                modelDownloader
+                                    .downloadModelFile(config.modelName(), status.modelFile().name(), file)
+                                    .doFinally(file::close)
+                                    .andThen(Single.just(Map.entry(status.modelFile().type(), status.outputPath().toString())))
+                                    .onErrorResumeNext(err ->
+                                        Single.error(
+                                            new ModelDownloadFailedException(
+                                                String.format("Download failed for model: %s", status.modelFile().name()),
+                                                err
                                             )
+                                        )
                                     )
-                                    .doOnSuccess(resp -> log.info("Download completed successfully: {}", modelFile.name()))
-                                    .doOnError(err -> log.error("Download failed", err));
-                            });
+                            )
+                            .doOnSuccess(resp -> log.info("Download completed successfully: {}", status.modelFile().name()))
+                            .doOnError(err -> log.error("Download failed", err));
                     })
             )
             .collect(() -> new EnumMap<>(ModelFileType.class), (map, entry) -> map.put(entry.getKey(), entry.getValue()));
     }
+
+    private record FileStatus(ModelFile modelFile, Path outputPath, boolean exists) {}
 
     private Single<AsyncFile> buildSubDirectoryAndOpenFile(Path outputPath) {
         return vertx.fileSystem().mkdirs(outputPath.getParent().toString()).andThen(openFile(outputPath));

--- a/src/test/java/downloader/HuggingFaceDownloaderTest.java
+++ b/src/test/java/downloader/HuggingFaceDownloaderTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 class HuggingFaceDownloaderTest {
 
     @Test
-    @DisplayName("Should skip download when file exists locally")
+    @DisplayName("Should skip download and HuggingFace listing when file exists locally")
     void shouldSkipDownloadWhenFileExistsLocally() {
         String modelName = "test-model";
         ModelFile file = new ModelFile("config.json", ModelFileType.CONFIG);
@@ -54,11 +54,9 @@ class HuggingFaceDownloaderTest {
         var vertx = mock(Vertx.class);
         var fileSystem = mock(FileSystem.class);
         when(vertx.fileSystem()).thenReturn(fileSystem);
-        when(vertx.fileSystem().mkdirs(any())).thenReturn(Completable.complete());
         when(fileSystem.rxExists(modelDir.resolve(file.name()).toString())).thenReturn(Single.just(true));
 
         var client = mock(VertxHuggingFaceClientRx.class);
-        when(client.listModelFiles(modelName)).thenReturn(Flowable.just("config.json"));
 
         var service = new HuggingFaceDownloader(vertx, client);
 
@@ -73,6 +71,41 @@ class HuggingFaceDownloaderTest {
                 return true;
             });
 
+        verify(client, never()).listModelFiles(any());
+        verify(client, never()).downloadModelFile(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip HuggingFace listing when all files exist locally")
+    void shouldSkipHuggingFaceWhenAllFilesExistLocally() {
+        String modelName = "test-model";
+        ModelFile configFile = new ModelFile("config.json", ModelFileType.CONFIG);
+        ModelFile modelFile = new ModelFile("model.onnx", ModelFileType.MODEL);
+        Path modelDir = Path.of("temp-model-dir");
+
+        var vertx = mock(Vertx.class);
+        var fileSystem = mock(FileSystem.class);
+        when(vertx.fileSystem()).thenReturn(fileSystem);
+        when(fileSystem.rxExists(modelDir.resolve(configFile.name()).toString())).thenReturn(Single.just(true));
+        when(fileSystem.rxExists(modelDir.resolve(modelFile.name()).toString())).thenReturn(Single.just(true));
+
+        var client = mock(VertxHuggingFaceClientRx.class);
+
+        var service = new HuggingFaceDownloader(vertx, client);
+
+        service
+            .fetchModel(new FetchModelConfig(modelName, List.of(configFile, modelFile), modelDir))
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(result -> {
+                assertThat(result.get(ModelFileType.CONFIG)).contains("config.json");
+                assertThat(result.get(ModelFileType.MODEL)).contains("model.onnx");
+                return true;
+            });
+
+        verify(client, never()).listModelFiles(any());
         verify(client, never()).downloadModelFile(any(), any(), any());
     }
 
@@ -155,10 +188,15 @@ class HuggingFaceDownloaderTest {
         ModelFile file = new ModelFile("missing.json", ModelFileType.MODEL);
         Path modelDir = Path.of("temp-model-dir");
 
+        var vertx = mock(Vertx.class);
+        var fileSystem = mock(FileSystem.class);
+        when(vertx.fileSystem()).thenReturn(fileSystem);
+        when(fileSystem.rxExists(modelDir.resolve(file.name()).toString())).thenReturn(Single.just(false));
+
         var client = mock(VertxHuggingFaceClientRx.class);
         when(client.listModelFiles(modelName)).thenReturn(Flowable.just("other_file.json"));
 
-        var fetcher = new HuggingFaceDownloader(mock(Vertx.class), client);
+        var fetcher = new HuggingFaceDownloader(vertx, client);
 
         fetcher.fetchModel(new FetchModelConfig(modelName, List.of(file), modelDir)).test().assertError(ModelFileNotFoundException.class);
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14371

# Intent

This PR optimizes the `HuggingFaceDownloader` by short-circuiting the HuggingFace API listing call when **all** requested model files already exist locally. Previously, even a fully-cached model would trigger a network round-trip to list remote files before deciding nothing needed to be downloaded. The fix pre-checks file existence for every requested file and returns immediately if all are present, falling back to the existing HuggingFace verification flow only when at least one file is missing.

# Reading order

## 1. The central decision — `fetchModel` refactor

- `src/main/java/io/gravitee/reactive/webclient/huggingface/downloader/HuggingFaceDownloader.java` — core implementation

  → `fetchModel` is split into two phases: (1) parallel existence check via `Flowable.fromIterable + flatMapSingle`, producing a `List<FileStatus>`; (2) if all files exist, build the result map immediately; otherwise delegate to `downloadWithHuggingFaceVerification`.
  The private `record FileStatus(ModelFile modelFile, Path outputPath, boolean exists)` bundles the three pieces of data that were previously recomputed at different stages.
  **Key subtlety**: in the partial-cache path, `downloadWithHuggingFaceVerification` receives *all* statuses (including already-existing files). The remote listing therefore still covers files that won't be re-downloaded — this is intentional (one API call, no extra fan-out) but worth noting during review.

## 2. Test adaptations

- `src/test/java/downloader/HuggingFaceDownloaderTest.java` — test updates

  → Three changes:
  1. `shouldSkipDownloadWhenFileExistsLocally` — `listModelFiles` mock removed; `verify(client, never()).listModelFiles(any())` added. Assertion now matches the new behaviour.
  2. New test `shouldSkipHuggingFaceWhenAllFilesExistLocally` — covers the multi-file all-cached scenario; verifies neither `listModelFiles` nor `downloadModelFile` is called.
  3. `shouldThrowExceptionWhenModelFileNotFoundOnHuggingFace` — vertx/filesystem mock added so the file-existence pre-check returns `false` before the code reaches the HuggingFace listing.

# Points of attention

- [ ] `HuggingFaceDownloader.java` (new `downloadWithHuggingFaceVerification`): In the partial-cache case, all statuses (including existing files) are passed to the HuggingFace listing step. The existing files are skipped individually by `if (status.exists())`. This means one `listModelFiles` call covers files that won't be downloaded — acceptable trade-off, but a reviewer should confirm this is intentional and not a leftover from the refactor.
- [ ] `fetchModel` — the all-exist short-circuit uses `statuses.stream().allMatch(FileStatus::exists)`. If `config.modelFiles()` is empty, `allMatch` returns `true` and an empty map is returned without any network call. Verify this edge case is correct for the domain.

# What can be skimmed

- The `doOnSuccess`/`doOnError`/`doFinally` log wiring — unchanged logic, just variable renames (`modelFile` → `status.modelFile()`).
- Import additions (`ModelFile`, `List`) — purely mechanical.
- Test assertions on result values — identical to what existed before.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-mba-apim-14371-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reactive/webclient/gravitee-reactive-webclient-huggingface/1.1.1-mba-apim-14371-SNAPSHOT/gravitee-reactive-webclient-huggingface-1.1.1-mba-apim-14371-SNAPSHOT.zip)
  <!-- Version placeholder end -->
