### PR TITLE
fix(downloader): skip HF listing when all files exist locally

### DIFF
--- a/src/main/java/io/gravitee/reactive/webclient/huggingface/downloader/HuggingFaceDownloader.java
+++ b/src/main/java/io/gravitee/reactive/webclient/huggingface/downloader/HuggingFaceDownloader.java
@@ -17,6 +17,7 @@ package io.gravitee.reactive.webclient.huggingface.downloader;
 
 import io.gravitee.reactive.webclient.api.FetchModelConfig;
 import io.gravitee.reactive.webclient.api.ModelFetcher;
+import io.gravitee.reactive.webclient.api.ModelFile;
 import io.gravitee.reactive.webclient.api.ModelFileType;
 import io.gravitee.reactive.webclient.huggingface.client.VertxHuggingFaceClientRx;
 import io.gravitee.reactive.webclient.huggingface.exception.ModelDownloadFailedException;
@@ -28,6 +29,7 @@ import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.file.AsyncFile;
 import java.nio.file.Path;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,53 +52,74 @@ public class HuggingFaceDownloader implements ModelFetcher {
 
     @Override
     public Single<Map<ModelFileType, String>> fetchModel(FetchModelConfig config) {
+        return Flowable.fromIterable(config.modelFiles())
+            .flatMapSingle(modelFile -> {
+                var outputPath = config.modelDirectory().resolve(modelFile.name());
+                return vertx
+                    .fileSystem()
+                    .rxExists(outputPath.toString())
+                    .map(exists -> new FileStatus(modelFile, outputPath, exists));
+            })
+            .toList()
+            .flatMap(statuses -> {
+                if (statuses.stream().allMatch(FileStatus::exists)) {
+                    log.info("All model files already exist locally, skipping HuggingFace listing");
+                    var result = new EnumMap<ModelFileType, String>(ModelFileType.class);
+                    statuses.forEach(s -> result.put(s.modelFile().type(), s.outputPath().toString()));
+                    return Single.just(result);
+                }
+                return downloadWithHuggingFaceVerification(config, statuses);
+            });
+    }
+
+    private Single<Map<ModelFileType, String>> downloadWithHuggingFaceVerification(FetchModelConfig config, List<FileStatus> statuses) {
         return modelDownloader
             .listModelFiles(config.modelName())
             .toList()
             .flatMapPublisher(availableFiles ->
-                Flowable.fromIterable(config.modelFiles()).flatMapSingle(modelFile -> {
-                    if (!availableFiles.contains(modelFile.name())) {
+                Flowable.fromIterable(statuses).flatMapSingle(status -> {
+                    if (status.exists()) {
+                        log.info("Skipping download; file already exists: {}", status.modelFile().name());
+                        return Single.just(Map.entry(status.modelFile().type(), status.outputPath().toString()));
+                    }
+                    if (!availableFiles.contains(status.modelFile().name())) {
                         return Single.error(
                             new ModelFileNotFoundException(
-                                String.format("Model file not found on HuggingFace: %s for model: %s", modelFile.name(), config.modelName())
+                                String.format(
+                                    "Model file not found on HuggingFace: %s for model: %s",
+                                    status.modelFile().name(),
+                                    config.modelName()
+                                )
                             )
                         );
                     }
 
-                    Path outputPath = config.modelDirectory().resolve(modelFile.name());
+                    boolean isFileInSubDirectory = status.outputPath().toString().contains("/");
 
-                    return vertx
-                        .fileSystem()
-                        .rxExists(outputPath.toString())
-                        .flatMap(exists -> {
-                            if (exists) {
-                                log.info("Skipping download; file already exists: {}", modelFile.name());
-                                return Single.just(Map.entry(modelFile.type(), outputPath.toString()));
-                            }
-
-                            boolean isFileInSubDirectory = outputPath.toString().contains("/");
-
-                            return (isFileInSubDirectory ? buildSubDirectoryAndOpenFile(outputPath) : openFile(outputPath)).flatMap(file ->
-                                    modelDownloader
-                                        .downloadModelFile(config.modelName(), modelFile.name(), file)
-                                        .doFinally(file::close)
-                                        .andThen(Single.just(Map.entry(modelFile.type(), outputPath.toString())))
-                                        .onErrorResumeNext(err ->
-                                            Single.error(
-                                                new ModelDownloadFailedException(
-                                                    String.format("Download failed for model: %s", modelFile.name()),
-                                                    err
-                                                )
-                                            )
+                    return (
+                        isFileInSubDirectory ? buildSubDirectoryAndOpenFile(status.outputPath()) : openFile(status.outputPath())
+                    ).flatMap(file ->
+                            modelDownloader
+                                .downloadModelFile(config.modelName(), status.modelFile().name(), file)
+                                .doFinally(file::close)
+                                .andThen(Single.just(Map.entry(status.modelFile().type(), status.outputPath().toString())))
+                                .onErrorResumeNext(err ->
+                                    Single.error(
+                                        new ModelDownloadFailedException(
+                                            String.format("Download failed for model: %s", status.modelFile().name()),
+                                            err
                                         )
+                                    )
                                 )
-                                .doOnSuccess(resp -> log.info("Download completed successfully: {}", modelFile.name()))
-                                .doOnError(err -> log.error("Download failed", err));
-                        });
+                        )
+                        .doOnSuccess(resp -> log.info("Download completed successfully: {}", status.modelFile().name()))
+                        .doOnError(err -> log.error("Download failed", err));
                 })
             )
             .collect(() -> new EnumMap<>(ModelFileType.class), (map, entry) -> map.put(entry.getKey(), entry.getValue()));
     }
+
+    private record FileStatus(ModelFile modelFile, Path outputPath, boolean exists) {}
 
     private Single<AsyncFile> buildSubDirectoryAndOpenFile(Path outputPath) {
         return vertx.fileSystem().mkdirs(outputPath.getParent().toString()).andThen(openFile(outputPath));

--- a/src/test/java/downloader/HuggingFaceDownloaderTest.java
+++ b/src/test/java/downloader/HuggingFaceDownloaderTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 class HuggingFaceDownloaderTest {
 
     @Test
-    @DisplayName("Should skip download when file exists locally")
+    @DisplayName("Should skip download and HuggingFace listing when file exists locally")
     void shouldSkipDownloadWhenFileExistsLocally() {
         String modelName = "test-model";
         ModelFile file = new ModelFile("config.json", ModelFileType.CONFIG);
@@ -54,11 +54,9 @@ class HuggingFaceDownloaderTest {
         var vertx = mock(Vertx.class);
         var fileSystem = mock(FileSystem.class);
         when(vertx.fileSystem()).thenReturn(fileSystem);
-        when(vertx.fileSystem().mkdirs(any())).thenReturn(Completable.complete());
         when(fileSystem.rxExists(modelDir.resolve(file.name()).toString())).thenReturn(Single.just(true));
 
         var client = mock(VertxHuggingFaceClientRx.class);
-        when(client.listModelFiles(modelName)).thenReturn(Flowable.just("config.json"));
 
         var service = new HuggingFaceDownloader(vertx, client);
 
@@ -73,6 +71,41 @@ class HuggingFaceDownloaderTest {
                 return true;
             });
 
+        verify(client, never()).listModelFiles(any());
+        verify(client, never()).downloadModelFile(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip HuggingFace listing when all files exist locally")
+    void shouldSkipHuggingFaceWhenAllFilesExistLocally() {
+        String modelName = "test-model";
+        ModelFile configFile = new ModelFile("config.json", ModelFileType.CONFIG);
+        ModelFile modelFile = new ModelFile("model.onnx", ModelFileType.MODEL);
+        Path modelDir = Path.of("temp-model-dir");
+
+        var vertx = mock(Vertx.class);
+        var fileSystem = mock(FileSystem.class);
+        when(vertx.fileSystem()).thenReturn(fileSystem);
+        when(fileSystem.rxExists(modelDir.resolve(configFile.name()).toString())).thenReturn(Single.just(true));
+        when(fileSystem.rxExists(modelDir.resolve(modelFile.name()).toString())).thenReturn(Single.just(true));
+
+        var client = mock(VertxHuggingFaceClientRx.class);
+
+        var service = new HuggingFaceDownloader(vertx, client);
+
+        service
+            .fetchModel(new FetchModelConfig(modelName, List.of(configFile, modelFile), modelDir))
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(result -> {
+                assertThat(result.get(ModelFileType.CONFIG)).contains("config.json");
+                assertThat(result.get(ModelFileType.MODEL)).contains("model.onnx");
+                return true;
+            });
+
+        verify(client, never()).listModelFiles(any());
         verify(client, never()).downloadModelFile(any(), any(), any());
     }
 
@@ -155,10 +188,15 @@ class HuggingFaceDownloaderTest {
         ModelFile file = new ModelFile("missing.json", ModelFileType.MODEL);
         Path modelDir = Path.of("temp-model-dir");
 
+        var vertx = mock(Vertx.class);
+        var fileSystem = mock(FileSystem.class);
+        when(vertx.fileSystem()).thenReturn(fileSystem);
+        when(fileSystem.rxExists(modelDir.resolve(file.name()).toString())).thenReturn(Single.just(false));
+
         var client = mock(VertxHuggingFaceClientRx.class);
         when(client.listModelFiles(modelName)).thenReturn(Flowable.just("other_file.json"));
 
-        var fetcher = new HuggingFaceDownloader(mock(Vertx.class), client);
+        var fetcher = new HuggingFaceDownloader(vertx, client);
 
         fetcher.fetchModel(new FetchModelConfig(modelName, List.of(file), modelDir)).test().assertError(ModelFileNotFoundException.class);
     }


### PR DESCRIPTION
BREAKING CHANGE: upgrade to Vert.x 5**Issue**

https://gravitee.atlassian.net/browse/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-mba-apim-14371-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reactive/webclient/gravitee-reactive-webclient-huggingface/2.0.0-mba-apim-14371-SNAPSHOT/gravitee-reactive-webclient-huggingface-2.0.0-mba-apim-14371-SNAPSHOT.zip)
  <!-- Version placeholder end -->
